### PR TITLE
Fixed link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For security purposes, DocuSign recommends using the [Authorization Code Grant](
 There are other use-case scenarios, such as **single-page applications** (SPA) that use **Cross-Origin Resource Sharing** (CORS), or where there may not be a user to interact with your Service Account. For these use cases, DocuSign also supports [JWT](https://developers.docusign.com/esign-rest-api/guides/authentication/oauth2-jsonwebtoken) and [Implicit](https://developers.docusign.com/esign-rest-api/guides/authentication/oauth2-implicit) grants. For Ccode eExamples, see the links below:
 
 - [JWT (JSON Web Token)](https://developers.docusign.com/esign-rest-api/guides/authentication/oauth2-jsonwebtoken)
-- [Implicit Grant] (https://developers.docusign.com/esign-rest-api/guides/authentication/oauth2-implicit)
+- [Implicit Grant](https://developers.docusign.com/esign-rest-api/guides/authentication/oauth2-implicit)
 
 ## Support
 


### PR DESCRIPTION
Fixed a space typo in the link tag of 'Implicit Grant' in OAuth Implementations section